### PR TITLE
Use a whitelist for loading project files

### DIFF
--- a/lib/rsense/server/command.rb
+++ b/lib/rsense/server/command.rb
@@ -35,6 +35,13 @@ end
 
 class Rsense::Server::Command::Command
   LoadResult = Java::org.cx4a.rsense::LoadResult
+
+  RUBY_FILE_EXTENSIONS = %w(.rb .rake .gemspec .ru .thor .rabl .jbuilder .podspec)
+
+  RUBY_FILE_NAMES = %w(Podfile Rakefile Vagrantfile Puppetfile Berksfile Appraisals Gemfile Guardfile Capfile Thorfile)
+
+  WHITELIST = RUBY_FILE_EXTENSIONS + RUBY_FILE_NAMES
+
   CompletionCandidate = Struct.new(
       :completion,
       :qualified_name,
@@ -95,7 +102,7 @@ class Rsense::Server::Command::Command
     feature = file.basename.to_s.sub(file.extname, "")
     return LoadResult.alreadyLoaded() if project.loaded?(file)
     return LoadResult.alreadyLoaded() if project.loaded?(feature)
-    return if file.extname =~ /(\.so|\.dylib|\.dll|\.java|\.class|\.jar|\.c$|\.h$|\.m$|\.js|\.html|\.css)/
+    return unless WHITELIST.any? { |ext| file.to_s.end_with?(ext) }
 
     project.loaded << file
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -22,7 +22,7 @@ describe "completions" do
     it "returns completions" do
       @script = TestMockscript.new
       compls = @script.code_complete
-      compls.size.must_equal(66)
+      compls.size.must_equal(62)
     end
 
 end


### PR DESCRIPTION
I think this should address https://github.com/rsense/rsense/issues/37 if I'm understanding correctly. Pulled this list of files that should be read as Ruby from emacs-prelude's list of file extensions and names to enable ruby-mode.

Now using `String#end_with?` to match the whitelist to catch both names like `test.rb` and names like `Rakefile`.
